### PR TITLE
Simplify approach to Grok chat client and dynamic clients

### DIFF
--- a/src/AI.Tests/AI.Tests.csproj
+++ b/src/AI.Tests/AI.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <NoWarn>OPENAI001;$(NoWarn)</NoWarn>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>

--- a/src/AI.Tests/GrokTests.cs
+++ b/src/AI.Tests/GrokTests.cs
@@ -16,17 +16,18 @@ public class GrokTests(ITestOutputHelper output)
             { "user", "What day is today?" },
         };
 
-        var grok = new GrokClient(Configuration["XAI_API_KEY"]!);
+        var chat = new GrokChatClient(Configuration["XAI_API_KEY"]!);
 
         var options = new GrokChatOptions
         {
             ModelId = "grok-3-mini",
             Search = GrokSearch.Auto,
-            Tools = [AIFunctionFactory.Create(() => DateTimeOffset.Now.ToString("O"), "get_date")]
+            Tools = [AIFunctionFactory.Create(() => DateTimeOffset.Now.ToString("O"), "get_date")],
+            AdditionalProperties = new()
+            {
+                { "foo", "bar" }
+            }
         };
-
-        var client = grok.GetChatClient("grok-3");
-        var chat = Assert.IsType<IChatClient>(client, false);
 
         var response = await chat.GetResponseAsync(messages, options);
         var getdate = response.Messages
@@ -50,9 +51,7 @@ public class GrokTests(ITestOutputHelper output)
 
         var transport = new TestPipelineTransport(HttpClientPipelineTransport.Shared, output);
 
-        var grok = new GrokClient(Configuration["XAI_API_KEY"]!, new OpenAI.OpenAIClientOptions() { Transport = transport })
-            .GetChatClient("grok-3")
-            .AsIChatClient()
+        var grok = new GrokChatClient(Configuration["XAI_API_KEY"]!, "grok-3", new OpenAI.OpenAIClientOptions() { Transport = transport })
             .AsBuilder()
             .UseFunctionInvocation()
             .Build();
@@ -103,9 +102,7 @@ public class GrokTests(ITestOutputHelper output)
 
         var transport = new TestPipelineTransport(HttpClientPipelineTransport.Shared, output);
 
-        var grok = new GrokClient(Configuration["XAI_API_KEY"]!, new OpenAI.OpenAIClientOptions() { Transport = transport });
-        var client = grok.GetChatClient("grok-3");
-        var chat = Assert.IsType<IChatClient>(client, false);
+        var chat = new GrokChatClient(Configuration["XAI_API_KEY"]!, "grok-3", new OpenAI.OpenAIClientOptions() { Transport = transport });
 
         var options = new ChatOptions
         {

--- a/src/AI/ChatExtensions.cs
+++ b/src/AI/ChatExtensions.cs
@@ -20,4 +20,28 @@ public static class ChatExtensions
         public Task<ChatResponse> GetResponseAsync(Chat chat, ChatOptions? options = null, CancellationToken cancellation = default)
             => client.GetResponseAsync((IEnumerable<ChatMessage>)chat, options, cancellation);
     }
+
+    extension(ChatOptions options)
+    {
+        /// <summary>
+        /// Sets the effort level for a reasoning AI model when generating responses, if supported 
+        /// by the model.
+        /// </summary>
+        public ReasoningEffort? ReasoningEffort
+        {
+            get => options.AdditionalProperties?.TryGetValue("reasoning_effort", out var value) == true && value is ReasoningEffort effort ? effort : null;
+            set
+            {
+                if (value is not null)
+                {
+                    options.AdditionalProperties ??= [];
+                    options.AdditionalProperties["reasoning_effort"] = value;
+                }
+                else
+                {
+                    options.AdditionalProperties?.Remove("reasoning_effort");
+                }
+            }
+        }
+    }
 }

--- a/src/AI/Grok/GrokChatClient.cs
+++ b/src/AI/Grok/GrokChatClient.cs
@@ -1,0 +1,116 @@
+﻿using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using OpenAI;
+
+namespace Devlooped.Extensions.AI;
+
+/// <summary>
+/// An <see cref="IChatClient"/> implementation for Grok.
+/// </summary>
+public class GrokChatClient : IChatClient
+{
+    readonly ConcurrentDictionary<string, IChatClient> clients = new();
+    readonly string apiKey;
+    readonly string modelId;
+    readonly ClientPipeline pipeline;
+    readonly OpenAIClientOptions options;
+
+    /// <summary>
+    /// Initializes the client with the specified API key and the default model ID "grok-3-mini".
+    /// </summary>
+    public GrokChatClient(string apiKey) : this(apiKey, "grok-3-mini", null) { }
+
+    /// <summary>
+    /// Initializes the client with the specified API key, model ID, and optional OpenAI client options.
+    /// </summary>
+    public GrokChatClient(string apiKey, string modelId, OpenAIClientOptions? options = default)
+    {
+        this.apiKey = apiKey;
+        this.modelId = modelId;
+        this.options = options ?? new();
+        this.options.Endpoint ??= new Uri("https://api.x.ai/v1");
+
+        // NOTE: by caching the pipeline, we speed up creation of new chat clients per model, 
+        // since the pipeline will be the same for all of them.
+        pipeline = new OpenAIClient(new ApiKeyCredential(apiKey), options).Pipeline;
+    }
+
+    /// <inheritdoc/>
+    public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellation = default)
+            => GetChatClient(options?.ModelId ?? modelId).GetResponseAsync(messages, SetOptions(options), cancellation);
+
+    /// <inheritdoc/>
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellation = default)
+            => GetChatClient(options?.ModelId ?? modelId).GetStreamingResponseAsync(messages, SetOptions(options), cancellation);
+
+    IChatClient GetChatClient(string modelId) => clients.GetOrAdd(modelId, model
+        => new PipelineClient(pipeline, options).GetChatClient(modelId).AsIChatClient());
+
+    static ChatOptions? SetOptions(ChatOptions? options)
+    {
+        if (options is null)
+            return null;
+
+        options.RawRepresentationFactory = _ =>
+        {
+            var result = new GrokCompletionOptions();
+            var grok = options as GrokChatOptions;
+            var search = grok?.Search;
+
+            if (options.Tools != null)
+            {
+                if (options.Tools.OfType<GrokSearchTool>().FirstOrDefault() is GrokSearchTool grokSearch)
+                    search = grokSearch.Mode;
+                else if (options.Tools.OfType<HostedWebSearchTool>().FirstOrDefault() is HostedWebSearchTool webSearch)
+                    search = GrokSearch.Auto;
+
+                // Grok doesn't support any other hosted search tools, so remove remaining ones
+                // so they don't get copied over by the OpenAI client.
+                //options.Tools = [.. options.Tools.Where(tool => tool is not HostedWebSearchTool)];
+            }
+
+            if (search != null)
+                result.Search = search.Value;
+
+            if (grok?.ReasoningEffort != null)
+            {
+                result.ReasoningEffortLevel = grok.ReasoningEffort switch
+                {
+                    ReasoningEffort.Low => OpenAI.Chat.ChatReasoningEffortLevel.Low,
+                    ReasoningEffort.High => OpenAI.Chat.ChatReasoningEffortLevel.High,
+                    _ => throw new ArgumentException($"Unsupported reasoning effort {grok.ReasoningEffort}")
+                };
+            }
+
+            return result;
+        };
+
+        return options;
+    }
+
+    void IDisposable.Dispose() { }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    // Allows creating the base OpenAIClient with a pre-created pipeline.
+    class PipelineClient(ClientPipeline pipeline, OpenAIClientOptions options) : OpenAIClient(pipeline, options) { }
+
+    class GrokCompletionOptions : OpenAI.Chat.ChatCompletionOptions
+    {
+        public GrokSearch Search { get; set; } = GrokSearch.Auto;
+
+        protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions? options)
+        {
+            base.JsonModelWriteCore(writer, options);
+
+            // "search_parameters": { "mode": "auto" } 
+            writer.WritePropertyName("search_parameters");
+            writer.WriteStartObject();
+            writer.WriteString("mode", Search.ToString().ToLowerInvariant());
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/AI/GrokExtensions.cs
+++ b/src/AI/GrokExtensions.cs
@@ -1,0 +1,8 @@
+﻿namespace Devlooped.Extensions.AI;
+
+/// <summary>
+/// 
+/// </summary>
+public static class GrokExtensions
+{
+}

--- a/src/AI/ReasoningEffort.cs
+++ b/src/AI/ReasoningEffort.cs
@@ -1,6 +1,20 @@
 ﻿namespace Devlooped.Extensions.AI;
 
 /// <summary>
-/// Reasoning effort an AI should apply when generating a response.
+/// Effort a reasoning model should apply when generating a response.
 /// </summary>
-public enum ReasoningEffort { Low, High }
+public enum ReasoningEffort
+{
+    /// <summary>
+    /// Low effort reasoning, which may result in faster responses but less detailed or accurate answers.
+    /// </summary>
+    Low,
+    /// <summary>
+    /// Grok in particular does not support this mode, so it will default to <see cref="Low"/>.
+    /// </summary>
+    Medium,
+    /// <summary>
+    /// High effort reasoning, which may take longer but provides more detailed and accurate responses.
+    /// </summary>
+    High
+}


### PR DESCRIPTION
We want to provide the intuitive behavior of honoring the ChatOptions.ModelId, which the OpenAI client doesn't do. In order to achieve this, we implement the switching in the new GrokChatClient instead, and keep the GrokClient as a fallback for existing code or other non-chat scenarios where the same endpoints might work (but it's not guaranteed at all).