### PR TITLE
Drop ctor overload not receiving a model

### DIFF
--- a/src/AI.Tests/GrokTests.cs
+++ b/src/AI.Tests/GrokTests.cs
@@ -16,7 +16,7 @@ public class GrokTests(ITestOutputHelper output)
             { "user", "What day is today?" },
         };
 
-        var chat = new GrokChatClient(Configuration["XAI_API_KEY"]!);
+        var chat = new GrokChatClient(Configuration["XAI_API_KEY"]!, "grok-3");
 
         var options = new GrokChatOptions
         {
@@ -143,15 +143,12 @@ public class GrokTests(ITestOutputHelper output)
         var messages = new Chat()
         {
             { "system", "You are an intelligent AI assistant that's an expert on financial matters." },
-            { "user", "If you have a debt of 100k and accumulate a compounding 5% debt on top of it every year, how long before you are a negative millonaire?" },
+            { "user", "If you have a debt of 100k and accumulate a compounding 5% debt on top of it every year, how long before you are a negative millonaire? (round up to full integer value)" },
         };
 
         var grok = new GrokClient(Configuration["XAI_API_KEY"]!)
             .GetChatClient("grok-3")
-            .AsIChatClient()
-            .AsBuilder()
-            .UseFunctionInvocation()
-            .Build();
+            .AsIChatClient();
 
         var options = new GrokChatOptions
         {

--- a/src/AI/Grok/GrokChatClient.cs
+++ b/src/AI/Grok/GrokChatClient.cs
@@ -13,22 +13,15 @@ namespace Devlooped.Extensions.AI;
 public class GrokChatClient : IChatClient
 {
     readonly ConcurrentDictionary<string, IChatClient> clients = new();
-    readonly string apiKey;
     readonly string modelId;
     readonly ClientPipeline pipeline;
     readonly OpenAIClientOptions options;
-
-    /// <summary>
-    /// Initializes the client with the specified API key and the default model ID "grok-3-mini".
-    /// </summary>
-    public GrokChatClient(string apiKey) : this(apiKey, "grok-3-mini", null) { }
 
     /// <summary>
     /// Initializes the client with the specified API key, model ID, and optional OpenAI client options.
     /// </summary>
     public GrokChatClient(string apiKey, string modelId, OpenAIClientOptions? options = default)
     {
-        this.apiKey = apiKey;
         this.modelId = modelId;
         this.options = options ?? new();
         this.options.Endpoint ??= new Uri("https://api.x.ai/v1");
@@ -79,9 +72,9 @@ public class GrokChatClient : IChatClient
             {
                 result.ReasoningEffortLevel = grok.ReasoningEffort switch
                 {
-                    ReasoningEffort.Low => OpenAI.Chat.ChatReasoningEffortLevel.Low,
                     ReasoningEffort.High => OpenAI.Chat.ChatReasoningEffortLevel.High,
-                    _ => throw new ArgumentException($"Unsupported reasoning effort {grok.ReasoningEffort}")
+                    // Grok does not support Medium, so we map it to Low too
+                    _ => OpenAI.Chat.ChatReasoningEffortLevel.Low,
                 };
             }
 

--- a/src/AI/GrokExtensions.cs
+++ b/src/AI/GrokExtensions.cs
@@ -1,8 +1,0 @@
-﻿namespace Devlooped.Extensions.AI;
-
-/// <summary>
-/// 
-/// </summary>
-public static class GrokExtensions
-{
-}


### PR DESCRIPTION
This will likely mean that sooner or later, an older enough library will default to a deprecated model and fail. So avoid that altogether.