### PR TITLE
Create a smarter OpenAI chat client that honors model ID

### DIFF
--- a/src/AI.Tests/AI.Tests.csproj
+++ b/src/AI.Tests/AI.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <NoWarn>OPENAI001;$(NoWarn)</NoWarn>
+    <LangVersion>Preview</LangVersion>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 

--- a/src/AI.Tests/OpenAITests.cs
+++ b/src/AI.Tests/OpenAITests.cs
@@ -1,0 +1,67 @@
+﻿using System.Text.Json.Nodes;
+using Microsoft.Extensions.AI;
+using static ConfigurationExtensions;
+
+namespace Devlooped.Extensions.AI;
+
+public class OpenAITests(ITestOutputHelper output)
+{
+    [SecretsFact("OPENAI_API_KEY")]
+    public async Task OpenAISwitchesModel()
+    {
+        var messages = new Chat()
+        {
+            { "user", "What products does Tesla make?" },
+        };
+
+        var chat = new OpenAIChatClient(Configuration["OPENAI_API_KEY"]!, "gpt-4.1-nano", new OpenAI.OpenAIClientOptions().WriteTo(output));
+
+        var options = new ChatOptions
+        {
+            ModelId = "gpt-4.1-mini",
+        };
+
+        var response = await chat.GetResponseAsync(messages, options);
+
+        // NOTE: the chat client was requested as grok-3 but the chat options wanted a 
+        // different model and the grok client honors that choice.
+        Assert.StartsWith("gpt-4.1-mini", response.ModelId);
+    }
+
+    [SecretsFact("OPENAI_API_KEY")]
+    public async Task OpenAIThinks()
+    {
+        var messages = new Chat()
+        {
+            { "system", "You are an intelligent AI assistant that's an expert on financial matters." },
+            { "user", "If you have a debt of 100k and accumulate a compounding 5% debt on top of it every year, how long before you are a negative millonaire? (round up to full integer value)" },
+        };
+
+        var requests = new List<JsonNode>();
+
+        var chat = new OpenAIChatClient(Configuration["OPENAI_API_KEY"]!, "o3-mini", new OpenAI.OpenAIClientOptions()
+            .WriteTo(output, requests.Add));
+
+        var options = new ChatOptions
+        {
+            ModelId = "o4-mini",
+            ReasoningEffort = ReasoningEffort.Medium
+        };
+
+        var response = await chat.GetResponseAsync(messages, options);
+
+        var text = response.Text;
+
+        Assert.Contains("48 years", text);
+        // NOTE: the chat client was requested as grok-3 but the chat options wanted a 
+        // different model and the grok client honors that choice.
+        Assert.StartsWith("o4-mini", response.ModelId);
+
+        // Reasoning should have been set to medium
+        Assert.All(requests, x =>
+        {
+            var search = Assert.IsType<JsonObject>(x["reasoning"]);
+            Assert.Equal("medium", search["effort"]?.GetValue<string>());
+        });
+    }
+}

--- a/src/AI/OpenAI/OpenAIChatClient.cs
+++ b/src/AI/OpenAI/OpenAIChatClient.cs
@@ -1,0 +1,71 @@
+﻿using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Concurrent;
+using Microsoft.Extensions.AI;
+using OpenAI;
+using OpenAI.Responses;
+
+namespace Devlooped.Extensions.AI;
+
+/// <summary>
+/// An <see cref="IChatClient"/> implementation for OpenAI.
+/// </summary>
+public class OpenAIChatClient : IChatClient
+{
+    readonly ConcurrentDictionary<string, IChatClient> clients = new();
+    readonly string modelId;
+    readonly ClientPipeline pipeline;
+    readonly OpenAIClientOptions? options;
+
+    /// <summary>
+    /// Initializes the client with the specified API key, model ID, and optional OpenAI client options.
+    /// </summary>
+    public OpenAIChatClient(string apiKey, string modelId, OpenAIClientOptions? options = default)
+    {
+        this.modelId = modelId;
+        this.options = options;
+
+        // NOTE: by caching the pipeline, we speed up creation of new chat clients per model, 
+        // since the pipeline will be the same for all of them.
+        pipeline = new OpenAIClient(new ApiKeyCredential(apiKey), options).Pipeline;
+    }
+
+    /// <inheritdoc/>
+    public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellation = default)
+            => GetChatClient(options?.ModelId ?? modelId).GetResponseAsync(messages, SetOptions(options), cancellation);
+
+    /// <inheritdoc/>
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellation = default)
+            => GetChatClient(options?.ModelId ?? modelId).GetStreamingResponseAsync(messages, SetOptions(options), cancellation);
+
+    IChatClient GetChatClient(string modelId) => clients.GetOrAdd(modelId, model
+        => new PipelineClient(pipeline, options).GetOpenAIResponseClient(modelId).AsIChatClient());
+
+    static ChatOptions? SetOptions(ChatOptions? options)
+    {
+        if (options is null)
+            return null;
+
+        if (options.ReasoningEffort is ReasoningEffort effort)
+        {
+            options.RawRepresentationFactory = _ => new ResponseCreationOptions
+            {
+                ReasoningOptions = new ResponseReasoningOptions(effort switch
+                {
+                    ReasoningEffort.High => ResponseReasoningEffortLevel.High,
+                    ReasoningEffort.Medium => ResponseReasoningEffortLevel.Medium,
+                    _ => ResponseReasoningEffortLevel.Low
+                })
+            };
+        }
+
+        return options;
+    }
+
+    void IDisposable.Dispose() { }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    // Allows creating the base OpenAIClient with a pre-created pipeline.
+    class PipelineClient(ClientPipeline pipeline, OpenAIClientOptions? options) : OpenAIClient(pipeline, options) { }
+}


### PR DESCRIPTION
When using `IChatClient` API, the `ChatOptions.ModelId` is ignored by the built-in OpenAI implementation obtained by invoking `OpenAIClient.GetChatClient("model").AsIChatClient`. This is because the `GetChatClient` stores the model passed in and doesn't respect the options-specified one after initial creation.

We now align our own implementation of `IChatClient` for OpenAI so it behaves like Grok's, allowing more flexible usage while following the natural expectation set by having a writable `ChatOptions.ModelId` in the first place :).