### PR TITLE
Add support for OpenAI web search options and Grok compat

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,25 @@ var options = new ChatOptions
 var response = await grok.GetResponseAsync(messages, options);
 ```
 
+We also provide an OpenAI-compatible `WebSearchTool` that can be used to restrict 
+the search to a specific country in a way that works with both Grok and OpenAI:
+
+```csharp
+var options = new ChatOptions
+{
+    Tools = [new WebSearchTool("AR")] // 👈 search in Argentina
+};
+```
+
+This is equivalent to the following when used with a Grok client:
+```csharp
+var options = new ChatOptions
+{
+    //                                           👇 search in Argentina
+    Tools = [new GrokSearchTool(GrokSearch.On) { Country = "AR" }] 
+};
+```
+
 ### Advanced Live Search
 
 To configure advanced live search options, beyond the `On|Auto|Off` settings 
@@ -127,8 +146,33 @@ var options = new ChatOptions
 };
 
 var response = await chat.GetResponseAsync(messages, options);
-
 ```
+
+### Web Search
+
+Similar to the Grok client, we provide the `WebSearchTool` to enable search customization 
+in OpenAI too:
+
+```csharp
+var options = new ChatOptions
+{
+    //                          👇 search in Argentina, Bariloche region
+    Tools = [new WebSearchTool("AR")
+    {
+        Region = "Bariloche",   // 👈 Bariloche region
+        TimeZone = "America/Argentina/Buenos_Aires", // 👈 IANA timezone
+        ContextSize = WebSearchContextSize.High      // 👈 high search context size
+    }]
+};
+```
+
+> [!NOTE]
+> This enables all features supported by the [Web search](https://platform.openai.com/docs/guides/tools-web-search) 
+> feature in OpenAI.
+
+If advanced search settings are not needed, you can use the built-in M.E.AI `HostedWebSearchTool` 
+instead, which is a more generic tool and provides the basics out of the box.
+
 
 ## Observing Request/Response
 

--- a/src/AI.Tests/GrokTests.cs
+++ b/src/AI.Tests/GrokTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Text.Json.Nodes;
+using Devlooped.Extensions.AI.Grok;
 using Microsoft.Extensions.AI;
 using static ConfigurationExtensions;
+using OpenAIClientOptions = OpenAI.OpenAIClientOptions;
 
 namespace Devlooped.Extensions.AI;
 
@@ -51,7 +53,7 @@ public class GrokTests(ITestOutputHelper output)
         var requests = new List<JsonNode>();
         var responses = new List<JsonNode>();
 
-        var grok = new GrokChatClient(Configuration["XAI_API_KEY"]!, "grok-3", OpenAI.OpenAIClientOptions
+        var grok = new GrokChatClient(Configuration["XAI_API_KEY"]!, "grok-3", OpenAIClientOptions
                     .Observable(requests.Add, responses.Add)
                     .WriteTo(output))
             .AsBuilder()
@@ -105,7 +107,7 @@ public class GrokTests(ITestOutputHelper output)
         var requests = new List<JsonNode>();
         var responses = new List<JsonNode>();
 
-        var grok = new GrokChatClient(Configuration["XAI_API_KEY"]!, "grok-3", OpenAI.OpenAIClientOptions
+        var grok = new GrokChatClient(Configuration["XAI_API_KEY"]!, "grok-3", OpenAIClientOptions
             .Observable(requests.Add, responses.Add)
             .WriteTo(output));
 
@@ -185,7 +187,7 @@ public class GrokTests(ITestOutputHelper output)
         var requests = new List<JsonNode>();
         var responses = new List<JsonNode>();
 
-        var grok = new GrokChatClient(Configuration["XAI_API_KEY"]!, "grok-3", OpenAI.OpenAIClientOptions
+        var grok = new GrokChatClient(Configuration["XAI_API_KEY"]!, "grok-3", OpenAIClientOptions
             .Observable(requests.Add, responses.Add)
             .WriteTo(output));
 

--- a/src/AI.Tests/RetrievalTests.cs
+++ b/src/AI.Tests/RetrievalTests.cs
@@ -11,11 +11,11 @@ public class RetrievalTests(ITestOutputHelper output)
     [InlineData("gpt-4.1-nano", "What's the battery life in an iPhone 15?", true)]
     public async Task CanRetrieveContent(string model, string question, bool empty = false)
     {
-        var client = new OpenAI.OpenAIClient(Configuration["OPENAI_API_KEY"]);
+        var client = new global::OpenAI.OpenAIClient(Configuration["OPENAI_API_KEY"]);
         var store = client.GetVectorStoreClient().CreateVectorStore(true);
         try
         {
-            var file = client.GetOpenAIFileClient().UploadFile("Content/LNS0004592.md", OpenAI.Files.FileUploadPurpose.Assistants);
+            var file = client.GetOpenAIFileClient().UploadFile("Content/LNS0004592.md", global::OpenAI.Files.FileUploadPurpose.Assistants);
             try
             {
                 client.GetVectorStoreClient().AddFileToVectorStore(store.VectorStoreId, file.Value.Id, true);

--- a/src/AI.Tests/ToolsTests.cs
+++ b/src/AI.Tests/ToolsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Devlooped.Extensions.AI.OpenAI;
 using Microsoft.Extensions.AI;
 using static ConfigurationExtensions;
 
@@ -18,7 +19,7 @@ public class ToolsTests(ITestOutputHelper output)
         };
 
         var client = new OpenAIChatClient(Configuration["OPENAI_API_KEY"]!, "gpt-4.1",
-            OpenAI.OpenAIClientOptions.WriteTo(output))
+            global::OpenAI.OpenAIClientOptions.WriteTo(output))
             .AsBuilder()
             .UseFunctionInvocation()
             .Build();
@@ -50,7 +51,7 @@ public class ToolsTests(ITestOutputHelper output)
         };
 
         var client = new OpenAIChatClient(Configuration["OPENAI_API_KEY"]!, "gpt-4.1",
-            OpenAI.OpenAIClientOptions.WriteTo(output))
+            global::OpenAI.OpenAIClientOptions.WriteTo(output))
             .AsBuilder()
             .UseFunctionInvocation()
             .Build();
@@ -82,7 +83,7 @@ public class ToolsTests(ITestOutputHelper output)
         };
 
         var client = new OpenAIChatClient(Configuration["OPENAI_API_KEY"]!, "gpt-4.1",
-            OpenAI.OpenAIClientOptions.WriteTo(output))
+            global::OpenAI.OpenAIClientOptions.WriteTo(output))
             .AsBuilder()
             .UseFunctionInvocation()
             .Build();

--- a/src/AI/Grok/GrokChatClient.cs
+++ b/src/AI/Grok/GrokChatClient.cs
@@ -7,7 +7,7 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.AI;
 using OpenAI;
 
-namespace Devlooped.Extensions.AI;
+namespace Devlooped.Extensions.AI.Grok;
 
 /// <summary>
 /// An <see cref="IChatClient"/> implementation for Grok.
@@ -64,6 +64,14 @@ public partial class GrokChatClient : IChatClient
                     Mode = search.Value
                 };
             }
+            else if (tool is null && options.Tools?.OfType<WebSearchTool>().FirstOrDefault() is { } web)
+            {
+                searchOptions = new GrokChatWebSearchOptions
+                {
+                    Mode = GrokSearch.Auto,
+                    Sources = [new GrokWebSource { Country = web.Country }]
+                };
+            }
             else if (tool is null && options.Tools?.OfType<HostedWebSearchTool>().FirstOrDefault() is not null)
             {
                 searchOptions = new GrokChatWebSearchOptions
@@ -92,9 +100,9 @@ public partial class GrokChatClient : IChatClient
             {
                 result.ReasoningEffortLevel = grok.ReasoningEffort switch
                 {
-                    ReasoningEffort.High => OpenAI.Chat.ChatReasoningEffortLevel.High,
+                    ReasoningEffort.High => global::OpenAI.Chat.ChatReasoningEffortLevel.High,
                     // Grok does not support Medium, so we map it to Low too
-                    _ => OpenAI.Chat.ChatReasoningEffortLevel.Low,
+                    _ => global::OpenAI.Chat.ChatReasoningEffortLevel.Low,
                 };
             }
 
@@ -111,7 +119,7 @@ public partial class GrokChatClient : IChatClient
     // Allows creating the base OpenAIClient with a pre-created pipeline.
     class PipelineClient(ClientPipeline pipeline, OpenAIClientOptions options) : OpenAIClient(pipeline, options) { }
 
-    class GrokChatWebSearchOptions : OpenAI.Chat.ChatWebSearchOptions
+    class GrokChatWebSearchOptions : global::OpenAI.Chat.ChatWebSearchOptions
     {
         public GrokSearch Mode { get; set; } = GrokSearch.Auto;
         public DateOnly? FromDate { get; set; }
@@ -166,7 +174,7 @@ public partial class GrokChatClient : IChatClient
         }
     }
 
-    class GrokCompletionOptions : OpenAI.Chat.ChatCompletionOptions
+    class GrokCompletionOptions : global::OpenAI.Chat.ChatCompletionOptions
     {
         protected override void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions? options)
         {

--- a/src/AI/Grok/GrokChatOptions.cs
+++ b/src/AI/Grok/GrokChatOptions.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.AI;
 
-namespace Devlooped.Extensions.AI;
+namespace Devlooped.Extensions.AI.Grok;
 
 /// <summary>
 /// Grok-specific chat options that extend the base <see cref="ChatOptions"/>

--- a/src/AI/Grok/GrokClient.cs
+++ b/src/AI/Grok/GrokClient.cs
@@ -4,7 +4,7 @@ using System.Collections.Concurrent;
 using Microsoft.Extensions.AI;
 using OpenAI;
 
-namespace Devlooped.Extensions.AI;
+namespace Devlooped.Extensions.AI.Grok;
 
 /// <summary>
 /// Provides an OpenAI compability client for Grok. It's recommended you 
@@ -26,7 +26,7 @@ public class GrokClient(string apiKey, OpenAIClientOptions? options = null)
     /// Returns an adapter that surfaces an <see cref="IChatClient"/> interface that 
     /// can be used directly in the <see cref="ChatClientBuilder"/> pipeline builder.
     /// </summary>
-    public override OpenAI.Chat.ChatClient GetChatClient(string model) => new GrokChatClientAdapter(this, model);
+    public override global::OpenAI.Chat.ChatClient GetChatClient(string model) => new GrokChatClientAdapter(this, model);
 
     static OpenAIClientOptions EnsureEndpoint(OpenAIClientOptions? options)
     {
@@ -39,7 +39,7 @@ public class GrokClient(string apiKey, OpenAIClientOptions? options = null)
     // OpenAI in MEAI docs. Most typical case would be to just create an <see cref="GrokChatClient"/> directly.
     // This throws on any non-IChatClient invoked methods in the AsIChatClient adapter, and 
     // forwards the IChatClient methods to the GrokChatClient implementation which is cached per client.
-    class GrokChatClientAdapter(GrokClient client, string model) : OpenAI.Chat.ChatClient, IChatClient
+    class GrokChatClientAdapter(GrokClient client, string model) : global::OpenAI.Chat.ChatClient, IChatClient
     {
         void IDisposable.Dispose() { }
 
@@ -60,10 +60,10 @@ public class GrokClient(string apiKey, OpenAIClientOptions? options = null)
             => client.GetChatClientImpl(options?.ModelId ?? model).GetStreamingResponseAsync(messages, options, cancellation);
 
         // These are the only two methods actually invoked by the AsIChatClient adapter from M.E.AI.OpenAI
-        public override Task<ClientResult<OpenAI.Chat.ChatCompletion>> CompleteChatAsync(IEnumerable<OpenAI.Chat.ChatMessage>? messages, OpenAI.Chat.ChatCompletionOptions? options = null, CancellationToken cancellationToken = default)
+        public override Task<ClientResult<global::OpenAI.Chat.ChatCompletion>> CompleteChatAsync(IEnumerable<global::OpenAI.Chat.ChatMessage>? messages, global::OpenAI.Chat.ChatCompletionOptions? options = null, CancellationToken cancellationToken = default)
             => throw new NotSupportedException($"Consume directly as an {nameof(IChatClient)} instead of invoking {nameof(OpenAIClientExtensions.AsIChatClient)} on this instance.");
 
-        public override AsyncCollectionResult<OpenAI.Chat.StreamingChatCompletionUpdate> CompleteChatStreamingAsync(IEnumerable<OpenAI.Chat.ChatMessage>? messages, OpenAI.Chat.ChatCompletionOptions? options = null, CancellationToken cancellationToken = default)
+        public override AsyncCollectionResult<global::OpenAI.Chat.StreamingChatCompletionUpdate> CompleteChatStreamingAsync(IEnumerable<global::OpenAI.Chat.ChatMessage>? messages, global::OpenAI.Chat.ChatCompletionOptions? options = null, CancellationToken cancellationToken = default)
             => throw new NotSupportedException($"Consume directly as an {nameof(IChatClient)} instead of invoking {nameof(OpenAIClientExtensions.AsIChatClient)} on this instance.");
 
         #region Unsupported
@@ -71,25 +71,25 @@ public class GrokClient(string apiKey, OpenAIClientOptions? options = null)
         public override ClientResult CompleteChat(BinaryContent? content, RequestOptions? options = null)
             => throw new NotSupportedException($"Consume directly as an {nameof(IChatClient)}.");
 
-        public override ClientResult<OpenAI.Chat.ChatCompletion> CompleteChat(IEnumerable<OpenAI.Chat.ChatMessage>? messages, OpenAI.Chat.ChatCompletionOptions? options = null, CancellationToken cancellationToken = default)
+        public override ClientResult<global::OpenAI.Chat.ChatCompletion> CompleteChat(IEnumerable<global::OpenAI.Chat.ChatMessage>? messages, global::OpenAI.Chat.ChatCompletionOptions? options = null, CancellationToken cancellationToken = default)
             => throw new NotSupportedException($"Consume directly as an {nameof(IChatClient)}.");
 
-        public override ClientResult<OpenAI.Chat.ChatCompletion> CompleteChat(params OpenAI.Chat.ChatMessage[] messages)
+        public override ClientResult<global::OpenAI.Chat.ChatCompletion> CompleteChat(params global::OpenAI.Chat.ChatMessage[] messages)
             => throw new NotSupportedException($"Consume directly as an {nameof(IChatClient)}.");
 
         public override Task<ClientResult> CompleteChatAsync(BinaryContent? content, RequestOptions? options = null)
             => throw new NotSupportedException($"Consume directly as an {nameof(IChatClient)}.");
 
-        public override Task<ClientResult<OpenAI.Chat.ChatCompletion>> CompleteChatAsync(params OpenAI.Chat.ChatMessage[] messages)
+        public override Task<ClientResult<global::OpenAI.Chat.ChatCompletion>> CompleteChatAsync(params global::OpenAI.Chat.ChatMessage[] messages)
             => throw new NotSupportedException($"Consume directly as an {nameof(IChatClient)}.");
 
-        public override CollectionResult<OpenAI.Chat.StreamingChatCompletionUpdate> CompleteChatStreaming(IEnumerable<OpenAI.Chat.ChatMessage>? messages, OpenAI.Chat.ChatCompletionOptions? options = null, CancellationToken cancellationToken = default)
+        public override CollectionResult<global::OpenAI.Chat.StreamingChatCompletionUpdate> CompleteChatStreaming(IEnumerable<global::OpenAI.Chat.ChatMessage>? messages, global::OpenAI.Chat.ChatCompletionOptions? options = null, CancellationToken cancellationToken = default)
             => throw new NotSupportedException($"Consume directly as an {nameof(IChatClient)}.");
 
-        public override CollectionResult<OpenAI.Chat.StreamingChatCompletionUpdate> CompleteChatStreaming(params OpenAI.Chat.ChatMessage[] messages)
+        public override CollectionResult<global::OpenAI.Chat.StreamingChatCompletionUpdate> CompleteChatStreaming(params global::OpenAI.Chat.ChatMessage[] messages)
             => throw new NotSupportedException($"Consume directly as an {nameof(IChatClient)}.");
 
-        public override AsyncCollectionResult<OpenAI.Chat.StreamingChatCompletionUpdate> CompleteChatStreamingAsync(params OpenAI.Chat.ChatMessage[] messages)
+        public override AsyncCollectionResult<global::OpenAI.Chat.StreamingChatCompletionUpdate> CompleteChatStreamingAsync(params global::OpenAI.Chat.ChatMessage[] messages)
             => throw new NotSupportedException($"Consume directly as an {nameof(IChatClient)}.");
 
         #endregion

--- a/src/AI/Grok/GrokSearchTool.cs
+++ b/src/AI/Grok/GrokSearchTool.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text.Json.Serialization;
 using Microsoft.Extensions.AI;
 
-namespace Devlooped.Extensions.AI;
+namespace Devlooped.Extensions.AI.Grok;
 
 /// <summary>
 /// Enables or disables Grok's live search capabilities.

--- a/src/AI/OpenAI/OpenAIChatClient.cs
+++ b/src/AI/OpenAI/OpenAIChatClient.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.AI;
 using OpenAI;
 using OpenAI.Responses;
 
-namespace Devlooped.Extensions.AI;
+namespace Devlooped.Extensions.AI.OpenAI;
 
 /// <summary>
 /// An <see cref="IChatClient"/> implementation for OpenAI.

--- a/src/AI/OpenAI/WebSearchToolExtensions.cs
+++ b/src/AI/OpenAI/WebSearchToolExtensions.cs
@@ -1,0 +1,92 @@
+﻿using OpenAI.Responses;
+
+namespace Devlooped.Extensions.AI.OpenAI;
+
+/// <summary>
+/// Controls how much context is retrieved from the web to help the tool formulate a response. 
+/// </summary>
+public enum WebSearchContextSize
+{
+    /// <summary>
+    /// Least context, lowest cost, fastest response, but potentially lower answer quality.
+    /// </summary>
+    Low,
+    /// <summary>
+    /// (default): Balanced context, cost, and latency.
+    /// </summary>
+    Medium,
+    /// <summary>
+    /// Most comprehensive context, highest cost, slower response.
+    /// </summary>
+    High
+}
+
+public static class OpenAIWebSearchToolExtensions
+{
+    extension(WebSearchTool web)
+    {
+        /// <summary>
+        /// Optional free text additional information about the region to be used in the search. 
+        /// </summary>
+        /// <see cref="https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses#user-location"/>
+        public string? Region
+        {
+            get => web.Properties.TryGetValue("Region", out var region) ? (string?)region : null;
+            set
+            {
+                web.Properties["Region"] = value;
+                web.Location = WebSearchToolLocation.CreateApproximateLocation(web.Country, value, web.City, web.TimeZone);
+            }
+        }
+
+        /// <summary>
+        /// Optional free text additional information about the city to be used in the search. 
+        /// </summary>
+        /// <see cref="https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses#user-location"/>
+        public string? City
+        {
+            get => web.Properties.TryGetValue("City", out var city) ? (string?)city : null;
+            set
+            {
+                web.Properties["City"] = value;
+                web.Location = WebSearchToolLocation.CreateApproximateLocation(web.Country, web.Region, value, web.TimeZone);
+            }
+        }
+
+        /// <summary>
+        /// Optional IANA timezone name to be used in the search.
+        /// </summary>
+        /// <see cref="https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses#user-location"/>
+        public string? TimeZone
+        {
+            get => web.Properties.TryGetValue("TimeZone", out var timeZone) ? (string?)timeZone : null;
+            set
+            {
+                web.Properties["TimeZone"] = value;
+                web.Location = WebSearchToolLocation.CreateApproximateLocation(web.Country, web.Region, web.City, value);
+            }
+        }
+
+        /// <summary>
+        /// Controls how much context is retrieved from the web to help the tool formulate a response. 
+        /// </summary>
+        public WebSearchContextSize? ContextSize
+        {
+            get => web.Properties.TryGetValue("ContextSize", out var size) && size is WebSearchContextSize contextSize
+                ? contextSize : null;
+            set
+            {
+                web.Properties["ContextSize"] = value;
+                if (value != null)
+                {
+                    web.ContextSize = value.Value switch
+                    {
+                        WebSearchContextSize.Low => WebSearchToolContextSize.Low,
+                        WebSearchContextSize.High => WebSearchToolContextSize.High,
+                        _ => WebSearchToolContextSize.Medium
+                    };
+                }
+            }
+        }
+    }
+}

--- a/src/AI/WebSearchTool.cs
+++ b/src/AI/WebSearchTool.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Extensions.AI;
+using OpenAI.Responses;
+
+namespace Devlooped.Extensions.AI;
+
+/// <summary>
+/// Basic web search tool that can limit the search to a specific country.
+/// </summary>
+public class WebSearchTool : HostedWebSearchTool
+{
+    Dictionary<string, object?> additionalProperties;
+    string? region;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebSearchTool"/> class with the specified country.
+    /// </summary>
+    /// <param name="country">ISO alpha-2 country code.</param>
+    public WebSearchTool(string country)
+    {
+        Country = country;
+        additionalProperties = new Dictionary<string, object?>
+        {
+            { nameof(WebSearchToolLocation), WebSearchToolLocation.CreateApproximateLocation(country) }
+        };
+    }
+
+    /// <summary>
+    /// Sets the user's country for web search results, using the ISO alpha-2 code.
+    /// </summary>
+    public string Country { get; }
+
+    internal WebSearchToolLocation Location
+    {
+        set => additionalProperties[nameof(WebSearchToolLocation)] = value;
+    }
+
+    internal WebSearchToolContextSize ContextSize
+    {
+        set => additionalProperties[nameof(WebSearchToolContextSize)] = value;
+    }
+
+    internal IDictionary<string, object?> Properties => additionalProperties;
+
+    /// <inheritdoc/>
+    public override IReadOnlyDictionary<string, object?> AdditionalProperties => additionalProperties;
+}


### PR DESCRIPTION
* Add OpenAI/Grok subnamespace: helps organize functionality areas
* Adds OpenAI WebSearchTool-specific extensions under that namespace: region, city, timezone, context size.
* Cross-provider compatibility by interpreting WebSearchTool as GrokSearch(Auto) with a GrokWebSource(country).