### PR TITLE
Only emit the ChatClientExtensions if package is referenced

### DIFF
--- a/src/AI.CodeAnalysis/ChatClientExtensionsGenerator.cs
+++ b/src/AI.CodeAnalysis/ChatClientExtensionsGenerator.cs
@@ -16,9 +16,16 @@ public class ChatClientExtensionsGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        context.RegisterSourceOutput(context.CompilationProvider,
-            (spc, _) =>
+        var provider = context.AnalyzerConfigOptionsProvider
+            .Select((options, _) => options.GlobalOptions.TryGetValue("build_property.HasDevloopedExtensionsAI", out var hasExtensions) ? !string.IsNullOrEmpty(hasExtensions) : false)
+            .Combine(context.CompilationProvider);
+
+        context.RegisterSourceOutput(provider,
+            (spc, source) =>
             {
+                if (!source.Left)
+                    return;
+
                 spc.AddSource(
                     $"Devlooped.{nameof(ThisAssembly.Resources.ChatClientExtensions)}.g.cs",
                     SourceText.From(ThisAssembly.Resources.ChatClientExtensions.Text, Encoding.UTF8));

--- a/src/AI/Devlooped.Extensions.AI.props
+++ b/src/AI/Devlooped.Extensions.AI.props
@@ -1,7 +1,12 @@
 ﻿<Project>
 
+  <PropertyGroup>
+    <HasDevloopedExtensionsAI>true</HasDevloopedExtensionsAI>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Update="@(Compile -> WithMetadataValue('NuGetPackageId', 'Devlooped.Extensions.AI'))" Visible="false" />
+    <CompilerVisibleProperty Include="HasDevloopedExtensionsAI" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Otherwise, InternalsVisibleTo from a core package to another can cause ambiguous matches.