### PR TITLE
Friendly error when non-matching SDK is used

### DIFF
--- a/src/AI/AI.csproj
+++ b/src/AI/AI.csproj
@@ -31,4 +31,14 @@
     <None Include="..\..\osmfeula.txt" Link="osmfeula.txt" PackagePath="OSMFEULA.txt" />
   </ItemGroup>
 
+  <Target Name="UpdateSdkPreviewVersion" BeforeTargets="GetPackageContents">
+    <!-- Update packaging version targets -->
+    <XmlPoke XmlInputPath="$(MSBuildProjectDirectory)\Devlooped.Extensions.AI.targets"
+				 Query="/Project/PropertyGroup/BuiltWithSdkPreview"
+				 Value="$(_NETCoreSdkIsPreview)"/>
+    <XmlPoke XmlInputPath="$(MSBuildProjectDirectory)\Devlooped.Extensions.AI.targets"
+				 Query="/Project/PropertyGroup/BuiltSdkPreviewVersion"
+				 Value="$(NETCoreSdkVersion)"/>
+  </Target>
+
 </Project>

--- a/src/AI/Devlooped.Extensions.AI.targets
+++ b/src/AI/Devlooped.Extensions.AI.targets
@@ -1,3 +1,9 @@
-﻿<Project>
-
+<Project>
+  <PropertyGroup>
+    <BuiltWithSdkPreview>true</BuiltWithSdkPreview>
+    <BuiltSdkPreviewVersion>10.0.100-preview.7.25380.108</BuiltSdkPreviewVersion>
+  </PropertyGroup>
+  <Target Name="EnsureSamePreviewSdkVersion" BeforeTargets="Build" Condition="'$(BuiltWithSdkPreview)' == 'true'">
+    <Error Condition="'$(_NETCoreSdkIsPreview)' == 'false' or '$(NETCoreSdkVersion)' != '$(BuiltSdkPreviewVersion)'" Text="This version was built with a preview SDK and requires a matching one. Please install SDK version $(BuiltSdkPreviewVersion) or update to a newer package version." />
+  </Target>
 </Project>


### PR DESCRIPTION
Since we are building with latest&greatest .NET to get the extension class syntax, consumers need to use a matching SDK in order for that to work.

Provide a compile-time error instead of the inscrutable alternative (unsupported language feature or what-not).

This will turn off itself when we ship with a stable SDK.